### PR TITLE
use default LayerSwitcher.css file instead of missing file layerswitc…

### DIFF
--- a/js/control/layerswitcher.js
+++ b/js/control/layerswitcher.js
@@ -2,7 +2,7 @@
  * Add a LayerSwitcher control to the map
  */
 import map from '../map'
-import './layerswitcher.css'
+import 'ol-ext/control/LayerSwitcher.css'
 
 /* LayerSwitcher control */
 import LayerSwitcher from 'ol-ext/control/LayerSwitcher'


### PR DESCRIPTION
…her.css

Failed to build with npm start due to missing file layerswitcher.css.
Changed reference to the default 'ol-ext/control/LayerSwitcher.css' file in the ol-ext package.